### PR TITLE
Improve NRFI modeling pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 This project predicts whether a run will be scored in the first inning (YRFI/NRFI).
 
 ### Features
-- Leak-free rolling averages for pitchers and team offense using `.shift().rolling()`.
-- Pitcher form metrics including `K_pct` and `BB_pct`.
-- Offense metrics such as `OBP_team`, `SLG_team`, `OPS_team`, `ISO_team`.
-- Support for ballpark factors and weather data.
+- Leak-free rolling averages for pitchers and offense computed with `.shift().rolling()` to avoid data leakage.
+- Pitcher form metrics including `K_pct`, `BB_pct` and rolling xERA.
+- Offense metrics such as `OBP_team`, `SLG_team`, `OPS_team`, `ISO_team`, and an approximate `wOBA_team`.
+- Support for ballpark factors and optional weather data.
+- Time-series cross validation evaluates both calibrated logistic regression and a tuned XGBoost model.
 
 ### Training
-`nrfi_pipeline.py` loads `final_training_data_clean_final.csv`, builds features, and performs time-series cross-validation. Metrics are printed and an XGBoost model is saved.
+`nrfi_pipeline.py` loads `final_training_data_clean_final.csv`, builds leak-free features and evaluates models with time-series cross-validation. Both logistic regression and XGBoost metrics are printed before a tuned XGBoost model is saved.
 
 Run:
 ```bash


### PR DESCRIPTION
## Summary
- prevent leakage with shifted rolling stats in `add_pitcher_form` and `add_team_offense`
- add short-window stats, xERA rolling, and lineup metrics like `wOBA_team`
- perform time-series CV for logistic regression and tuned XGBoost
- expose probability threshold in predictions
- document updated workflow in README

## Testing
- `python nrfi_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_6842542509e88322a2adbeb031922a99