### PR TITLE
Add half-inning predictions and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,6 @@ After installing the requirements, run:
 python predict_today.py
 ```
 
-This script outputs NRFI/YRFI probabilities for the **entire** first inning and saves them to `predictions.txt`.
+`predict_today.py` fetches the daily games and outputs probabilities for each half
+of the first inning as well as the combined total for the entire inning. The
+results are written to `predictions.txt`.

--- a/predictions.txt
+++ b/predictions.txt
@@ -1,24 +1,9 @@
-team	pitcher_name	P_YRFI	P_NRFI
-Colorado Rockies	Kodai Senga	0.419493	0.580507
-New York Yankees	Walker Buehler	0.412303	0.587697
-Detroit Tigers	Ben Brown	0.408580	0.591420
-Cleveland Guardians	Colton Gordon	0.408502	0.591498
-Chicago White Sox	Seth Lugo	0.404967	0.595033
-Pittsburgh Pirates	Joe Ross	0.404967	0.595033
-Texas Rangers	Michael Soroka	0.402462	0.597538
-Washington Nationals	Patrick Corbin	0.398542	0.601458
-Los Angeles Angels	Bryce Miller	0.398286	0.601714
-St. Louis Cardinals	Justin Wrobleski	0.398286	0.601714
-San Francisco Giants	Spencer Schwellenbach	0.398286	0.601714
-Milwaukee Brewers	Randy Vásquez	0.398286	0.601714
-Kansas City Royals	Davis Martin	0.391052	0.608948
-Philadelphia Phillies	Bailey Falter	0.391052	0.608948
-New York Mets	Antonio Senzatela	0.380800	0.619200
-Chicago Cubs	Tarik Skubal	0.378143	0.621857
-Arizona Diamondbacks	Nick Lodolo	0.378143	0.621857
-Houston Astros	Logan Allen	0.378143	0.621857
-Boston Red Sox	Will Warren	0.357738	0.642262
-San Diego Padres	Chad Patrick	0.357738	0.642262
-Atlanta Braves	Hayden Birdsong	0.357738	0.642262
-Los Angeles Dodgers	Sonny Gray	0.342833	0.657167
-Seattle Mariners	Kyle Hendricks	0.342833	0.657167
+matchup	P_YRFI_Top	P_NRFI_Top	P_YRFI_Bot	P_NRFI_Bot	P_YRFI_total	P_NRFI_total
+Atlanta Braves @ Milwaukee Brewers	0.402462	0.597538	0.401717	0.598283	0.642503	0.357497
+Los Angeles Dodgers @ San Diego Padres	0.373667	0.626333	0.419493	0.580507	0.636409	0.363591
+Toronto Blue Jays @ St. Louis Cardinals	0.378143	0.621857	0.412303	0.587697	0.634536	0.365464
+Tampa Bay Rays @ Boston Red Sox	0.361712	0.638288	0.419493	0.580507	0.629469	0.370531
+Seattle Mariners @ Arizona Diamondbacks	0.370512	0.629488	0.408502	0.591498	0.627659	0.372341
+Miami Marlins @ Pittsburgh Pirates	0.357738	0.642262	0.398286	0.601714	0.613542	0.386458
+Chicago Cubs @ Philadelphia Phillies	0.360852	0.639148				
+Cincinnati Reds @ Cleveland Guardians			0.426203	0.573797		


### PR DESCRIPTION
## Summary
- predict each half inning and entire inning in `predict_today.py`
- document how the script outputs per half-inning results
- update example predictions

## Testing
- `pip install -r requirements.txt`
- `python predict_today.py`

------
https://chatgpt.com/codex/tasks/task_e_68470f5509688322adbe7039803c2ca8