### PR TITLE
Update README with dataset stats and probability details

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Run:
 ```bash
 python nrfi_pipeline.py
 ```
+### Dataset Balance
+`final_training_data_clean_final.csv` holds 4,344 labeled half-innings. A label of `1` represents a YRFI (a run scored) while `0` means NRFI. The file contains 2,518 YRFI rows (about 58%) and 1,826 NRFI rows (about 42%).
+
 
 ### Daily Predictions
 
@@ -32,6 +35,8 @@ After installing the requirements, run:
 ```bash
 python predict_today.py
 ```
+
+The script multiplies the predicted probabilities for the top and bottom halves of the first inning, effectively assuming they are independent events. This means `P_YRFI_total` can be higher than either half on its own.
 
 `predict_today.py` fetches the daily games and outputs probabilities for each half
 of the first inning as well as the combined total for the entire inning. The


### PR DESCRIPTION
## Summary
- mention label proportions in `final_training_data_clean_final.csv`
- clarify that `predict_today.py` multiplies top/bottom half probabilities

## Testing
- `python -m py_compile nrfi_pipeline.py predict_today.py`

------
https://chatgpt.com/codex/tasks/task_e_684756aa35cc8322aa703cb1c306e767